### PR TITLE
🐛 :: Append closure to observers before executing

### DIFF
--- a/LightweightObservable/Classes/Observable.swift
+++ b/LightweightObservable/Classes/Observable.swift
@@ -158,8 +158,9 @@ public final class Variable<T>: Observable<T> {
 
     override public func subscribe(_ observer: @escaping Observer) -> Disposable {
         // A variable should inform the observer with the initial value.
+        let disposable = super.subscribe(observer)
         observer(_value, nil)
 
-        return super.subscribe(observer)
+        return disposable
     }
 }


### PR DESCRIPTION
When subscribing to a `Variable<T>` the initial value triggers the provided closure. If the closure makes changes to the underlying value of the same `Variable<T>` the closure does not re-trigger on its first run.  

**Sample Code Showcasing Issue**

```swift
enum ExampleEnum {
    case initialValue
    case secondaryValue
}

let exampleVariable = Variable<ExampleEnum>(.initialValue)

let disposable = exampleVariable.subscribe({ new, old in
    if new == .initialValue {
        print("InitialValue")
        exampleVariable.value = .secondaryValue
    }
    if new == .secondaryValue {
        print("SecondaryValue")
    }
})
```

**Expected Output**
InitialValue
SecondaryValue

**Actual Output**
InitialValue

**Solution**
The proposed changes make it so the closure is added to the observer list before it's executed for the first time